### PR TITLE
Don't export ContractionProvider

### DIFF
--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -21,8 +21,7 @@
         <provider
             android:name=".provider.ContractionProvider"
             android:authorities="com.ianhanniballake.contractiontimer"
-            android:exported="true"
-            tools:ignore="ExportedContentProvider">
+            android:exported="false">
             <grant-uri-permission android:pathPattern=".*"/>
         </provider>
         <provider


### PR DESCRIPTION
Avoid SQL injection issues by making ContractionProvider non-exported.

Fixes #136 